### PR TITLE
Improve help menu

### DIFF
--- a/Equinox/Equinox.xcodeproj/project.pbxproj
+++ b/Equinox/Equinox.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  cd ..\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if test -d \"${HOME}/.mint/bin\"; then\n  PATH=\"${HOME}/.mint/bin/:${PATH}\"\nfi\n\nif test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  cd ..\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Equinox/Equinox.xcodeproj/project.pbxproj
+++ b/Equinox/Equinox.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3D916CE428B1682700D29FFF /* HelpMenuLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D916CE328B1682700D29FFF /* HelpMenuLinks.swift */; };
 		F3003226213081F0008D1352 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3003225213081F0008D1352 /* AppDelegate.swift */; };
 		F30C86DC26D6CEE600F93E60 /* WallpaperType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30C86DB26D6CEE600F93E60 /* WallpaperType.swift */; };
 		F30C86E626DC761300F93E60 /* RoundedPushButtonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30C86E526DC761300F93E60 /* RoundedPushButtonExtensions.swift */; };
@@ -76,6 +77,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3D916CE328B1682700D29FFF /* HelpMenuLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpMenuLinks.swift; sourceTree = "<group>"; };
 		F3003222213081F0008D1352 /* Equinox.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Equinox.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3003225213081F0008D1352 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F300322C213081F0008D1352 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 				F3D2EE4A267EDA18009704C5 /* ApplicationMenu.swift */,
 				F3E14A632742049400D986B6 /* DockMenu.swift */,
 				F3D2EE4F267EE774009704C5 /* MenuItem.swift */,
+				3D916CE328B1682700D29FFF /* HelpMenuLinks.swift */,
 			);
 			path = Menu;
 			sourceTree = "<group>";
@@ -432,6 +435,7 @@
 				F329B3DE26F6838500A31035 /* WallpaperGalleryDataController.swift in Sources */,
 				F356C8B1272F78B500E915C6 /* SolarTimezoneController.swift in Sources */,
 				F30C86DC26D6CEE600F93E60 /* WallpaperType.swift in Sources */,
+				3D916CE428B1682700D29FFF /* HelpMenuLinks.swift in Sources */,
 				F3E7B05E26ADE71100287C60 /* GalleryContentViewExtensions.swift in Sources */,
 				F32F3778273AD25400A52762 /* WorkspaceRunner.swift in Sources */,
 				F3AC410E26D57AA1000A7253 /* WallpaperRootViewController.swift in Sources */,

--- a/Equinox/Equinox/Menu/ApplicationMenu.swift
+++ b/Equinox/Equinox/Menu/ApplicationMenu.swift
@@ -217,7 +217,7 @@ final class ApplicationMenu: NSMenu {
     private var helpMenu: MenuItem {
         let menu = MenuItem()
         menu.submenu = NSMenu(title: Localization.Menu.Help.help)
-        helpMenuLinks.allCases.enumerated().forEach { helpMenuIndex, helpLink in
+        helpMenuLinks.allCases.forEach { helpLink in
             let menuItem = MenuItem(
                 title: helpLink.linkInfo.title,
                 keyEquivalent: "",
@@ -226,10 +226,8 @@ final class ApplicationMenu: NSMenu {
                 target: self
             )
             menu.submenu?.items.append(menuItem)
-            if helpMenuIndex == 2 {
-                menu.submenu?.items.append(MenuItem.separator())
-            }
         }
+        menu.submenu?.items.insert(MenuItem.separator(), at: 3)
         return menu
     }
     
@@ -263,29 +261,27 @@ final class ApplicationMenu: NSMenu {
         applicationDelegate?.applicationMenuNew(sender)
     }
     
-    @objc func unwrapOpenURL(_ url: URL?) {
-        guard let url = url else {
-            return
-        }
-        NSWorkspace.shared.open(url)
-    }
-    
     @objc func openURL(_ sender: NSMenuItem) {
-        switch sender.title {
+        var url: URL?
+        switch sender.title { // TODO : use an id instead of MenuItem title 
         case "GitHub project":
-            unwrapOpenURL(helpMenuLinks.githubProject.linkInfo.url)
+            url = helpMenuLinks.githubProject.linkInfo.url
         case "Frequently Asked Questions":
-            unwrapOpenURL(helpMenuLinks.githubFAQ.linkInfo.url)
+            url = helpMenuLinks.githubFAQ.linkInfo.url
         case "Report an issue":
-            unwrapOpenURL(helpMenuLinks.githubIssue.linkInfo.url)
+            url = helpMenuLinks.githubIssue.linkInfo.url
         case "Equinox website":
-            unwrapOpenURL(helpMenuLinks.equinoxWebsite.linkInfo.url)
+            url = helpMenuLinks.equinoxWebsite.linkInfo.url
         case "Rate Equinox on the Mac App Store":
-            unwrapOpenURL(helpMenuLinks.macAppStoreReview.linkInfo.url)
+            url = helpMenuLinks.macAppStoreReview.linkInfo.url
         case "Equinox on Product Hunt":
-            unwrapOpenURL(helpMenuLinks.productHunt.linkInfo.url)
+            url = helpMenuLinks.productHunt.linkInfo.url
         default:
             return
         }
+        guard let unwrappedURL = url else {
+            return
+        }
+        NSWorkspace.shared.open(unwrappedURL)
     }
 }

--- a/Equinox/Equinox/Menu/ApplicationMenu.swift
+++ b/Equinox/Equinox/Menu/ApplicationMenu.swift
@@ -225,6 +225,7 @@ final class ApplicationMenu: NSMenu {
                 action: #selector(openURL(_:)),
                 target: self
             )
+            menuItem.representedObject = helpLink.linkInfo.url
             menu.submenu?.items.append(menuItem)
         }
         menu.submenu?.items.insert(MenuItem.separator(), at: 3)
@@ -237,24 +238,7 @@ final class ApplicationMenu: NSMenu {
     }
     
     @objc func openURL(_ sender: NSMenuItem) {
-        var url: URL?
-        switch sender.title { // TODO : use an id instead of MenuItem title 
-        case "GitHub project":
-            url = helpMenuLinks.githubProject.linkInfo.url
-        case "Frequently Asked Questions":
-            url = helpMenuLinks.githubFAQ.linkInfo.url
-        case "Report an issue":
-            url = helpMenuLinks.githubIssue.linkInfo.url
-        case "Equinox website":
-            url = helpMenuLinks.equinoxWebsite.linkInfo.url
-        case "Rate Equinox on the Mac App Store":
-            url = helpMenuLinks.macAppStoreReview.linkInfo.url
-        case "Equinox on Product Hunt":
-            url = helpMenuLinks.productHunt.linkInfo.url
-        default:
-            return
-        }
-        guard let unwrappedURL = url else {
+        guard let unwrappedURL = sender.representedObject as? URL else {
             return
         }
         NSWorkspace.shared.open(unwrappedURL)

--- a/Equinox/Equinox/Menu/ApplicationMenu.swift
+++ b/Equinox/Equinox/Menu/ApplicationMenu.swift
@@ -231,31 +231,6 @@ final class ApplicationMenu: NSMenu {
         return menu
     }
     
-    private enum helpMenuLinks: CaseIterable {
-        case githubProject
-        case githubFAQ
-        case githubIssue
-        case equinoxWebsite
-        case macAppStoreReview
-        case productHunt
-        var linkInfo: (title: String, url: URL?) {
-            switch self {
-            case .githubProject:
-                return ("GitHub project", URL(string: "https://github.com/rlxone/Equinox"))
-            case .githubFAQ:
-                return ("Frequently Asked Questions", URL(string: "https://github.com/rlxone/Equinox#faq"))
-            case .githubIssue:
-                return ("Report an issue", URL(string: "https://github.com/rlxone/Equinox/issues"))
-            case .equinoxWebsite:
-                return ("Equinox website", URL(string: "https://equinoxmac.com"))
-            case .macAppStoreReview:
-                return ("Rate Equinox on the Mac App Store", URL(string: "https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?action=write-review"))
-            case .productHunt:
-                return ("Equinox on Product Hunt", URL(string: "https://www.producthunt.com/products/equinox"))
-            }
-        }
-    }
-    
     @objc
     private func new(_ sender: Any?) {
         applicationDelegate?.applicationMenuNew(sender)

--- a/Equinox/Equinox/Menu/ApplicationMenu.swift
+++ b/Equinox/Equinox/Menu/ApplicationMenu.swift
@@ -217,7 +217,7 @@ final class ApplicationMenu: NSMenu {
     private var helpMenu: MenuItem {
         let menu = MenuItem()
         menu.submenu = NSMenu(title: Localization.Menu.Help.help)
-        helpMenuLinks.allCases.forEach { helpLink in
+        HelpMenuLinks.allCases.forEach { helpLink in
             let menuItem = MenuItem(
                 title: helpLink.linkInfo.title,
                 keyEquivalent: "",
@@ -237,7 +237,8 @@ final class ApplicationMenu: NSMenu {
         applicationDelegate?.applicationMenuNew(sender)
     }
     
-    @objc func openURL(_ sender: NSMenuItem) {
+    @objc
+    private func openURL(_ sender: NSMenuItem) {
         guard let unwrappedURL = sender.representedObject as? URL else {
             return
         }

--- a/Equinox/Equinox/Menu/ApplicationMenu.swift
+++ b/Equinox/Equinox/Menu/ApplicationMenu.swift
@@ -217,62 +217,45 @@ final class ApplicationMenu: NSMenu {
     private var helpMenu: MenuItem {
         let menu = MenuItem()
         menu.submenu = NSMenu(title: Localization.Menu.Help.help)
-        menu.submenu?.items = [
-            MenuItem.separator(),
-            MenuItem(
-                title: "GitHub project",
+        helpMenuLinks.allCases.enumerated().forEach { helpMenuIndex, helpLink in
+            let menuItem = MenuItem(
+                title: helpLink.linkInfo.title,
                 keyEquivalent: "",
                 keyModifier: .command,
-                action: #selector(openGitHubProjectURL),
-                target: self
-            ),
-            MenuItem(
-                title: "Frequently Asked Questions",
-                keyEquivalent: "",
-                keyModifier: .command,
-                action: #selector(openGitHubFAQURL),
-                target: self
-            ),
-            MenuItem(
-                title: "Report an issue",
-                keyEquivalent: "",
-                keyModifier: .command,
-                action: #selector(openGitHubIssueURL),
-                target: self
-            ),
-            MenuItem.separator(),
-            MenuItem(
-                title: "Equinox website",
-                keyEquivalent: "",
-                keyModifier: .command,
-                action: #selector(openEquinoxWebsiteURL),
-                target: self
-            ),
-            MenuItem(
-                title: "Rate Equinox on the Mac App Store",
-                keyEquivalent: "",
-                keyModifier: .command,
-                action: #selector(openMacAppStoreReviewURL),
-                target: self
-            ),
-            MenuItem(
-                title: "Equinox on Product Hunt",
-                keyEquivalent: "",
-                keyModifier: .command,
-                action: #selector(openProductHuntURL),
+                action: #selector(openURL(_:)),
                 target: self
             )
-        ]
+            menu.submenu?.items.append(menuItem)
+            if helpMenuIndex == 2 {
+                menu.submenu?.items.append(MenuItem.separator())
+            }
+        }
         return menu
     }
     
-    private enum helpURLs: String {
-        case githubProjectURL = "https://github.com/rlxone/Equinox"
-        case githubFAQURL = "https://github.com/rlxone/Equinox#faq"
-        case githubIssueURL = "https://github.com/rlxone/Equinox/issues"
-        case equinoxWebsiteURL = "https://equinoxmac.com"
-        case macAppStoreReviewURL = "https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?action=write-review"
-        case productHuntURL = "https://www.producthunt.com/products/equinox"
+    private enum helpMenuLinks: CaseIterable {
+        case githubProject
+        case githubFAQ
+        case githubIssue
+        case equinoxWebsite
+        case macAppStoreReview
+        case productHunt
+        var linkInfo: (title: String, url: URL?) {
+            switch self {
+            case .githubProject:
+                return ("GitHub project", URL(string: "https://github.com/rlxone/Equinox"))
+            case .githubFAQ:
+                return ("Frequently Asked Questions", URL(string: "https://github.com/rlxone/Equinox#faq"))
+            case .githubIssue:
+                return ("Report an issue", URL(string: "https://github.com/rlxone/Equinox/issues"))
+            case .equinoxWebsite:
+                return ("Equinox website", URL(string: "https://equinoxmac.com"))
+            case .macAppStoreReview:
+                return ("Rate Equinox on the Mac App Store", URL(string: "https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?action=write-review"))
+            case .productHunt:
+                return ("Equinox on Product Hunt", URL(string: "https://www.producthunt.com/products/equinox"))
+            }
+        }
     }
     
     @objc
@@ -287,22 +270,22 @@ final class ApplicationMenu: NSMenu {
         NSWorkspace.shared.open(url)
     }
     
-    @objc func openGitHubProjectURL() {
-        unwrapOpenURL(URL(string: helpURLs.githubProjectURL.rawValue))
-    }
-    @objc func openGitHubFAQURL() {
-        unwrapOpenURL(URL(string: helpURLs.githubFAQURL.rawValue))
-    }
-    @objc func openGitHubIssueURL() {
-        unwrapOpenURL(URL(string: helpURLs.githubIssueURL.rawValue))
-    }
-    @objc func openEquinoxWebsiteURL() {
-        unwrapOpenURL(URL(string: helpURLs.equinoxWebsiteURL.rawValue))
-    }
-    @objc func openMacAppStoreReviewURL() {
-        unwrapOpenURL(URL(string: helpURLs.macAppStoreReviewURL.rawValue))
-    }
-    @objc func openProductHuntURL() {
-        unwrapOpenURL(URL(string: helpURLs.productHuntURL.rawValue))
+    @objc func openURL(_ sender: NSMenuItem) {
+        switch sender.title {
+        case "GitHub project":
+            unwrapOpenURL(helpMenuLinks.githubProject.linkInfo.url)
+        case "Frequently Asked Questions":
+            unwrapOpenURL(helpMenuLinks.githubFAQ.linkInfo.url)
+        case "Report an issue":
+            unwrapOpenURL(helpMenuLinks.githubIssue.linkInfo.url)
+        case "Equinox website":
+            unwrapOpenURL(helpMenuLinks.equinoxWebsite.linkInfo.url)
+        case "Rate Equinox on the Mac App Store":
+            unwrapOpenURL(helpMenuLinks.macAppStoreReview.linkInfo.url)
+        case "Equinox on Product Hunt":
+            unwrapOpenURL(helpMenuLinks.productHunt.linkInfo.url)
+        default:
+            return
+        }
     }
 }

--- a/Equinox/Equinox/Menu/ApplicationMenu.swift
+++ b/Equinox/Equinox/Menu/ApplicationMenu.swift
@@ -216,17 +216,93 @@ final class ApplicationMenu: NSMenu {
     
     private var helpMenu: MenuItem {
         let menu = MenuItem()
-        let menuSearch = MenuItem()
-        menuSearch.view = NSTextField()
         menu.submenu = NSMenu(title: Localization.Menu.Help.help)
         menu.submenu?.items = [
-            menuSearch
+            MenuItem.separator(),
+            MenuItem(
+                title: "GitHub project",
+                keyEquivalent: "",
+                keyModifier: .command,
+                action: #selector(openGitHubProjectURL),
+                target: self
+            ),
+            MenuItem(
+                title: "Frequently Asked Questions",
+                keyEquivalent: "",
+                keyModifier: .command,
+                action: #selector(openGitHubFAQURL),
+                target: self
+            ),
+            MenuItem(
+                title: "Report an issue",
+                keyEquivalent: "",
+                keyModifier: .command,
+                action: #selector(openGitHubIssueURL),
+                target: self
+            ),
+            MenuItem.separator(),
+            MenuItem(
+                title: "Equinox website",
+                keyEquivalent: "",
+                keyModifier: .command,
+                action: #selector(openEquinoxWebsiteURL),
+                target: self
+            ),
+            MenuItem(
+                title: "Rate Equinox on the Mac App Store",
+                keyEquivalent: "",
+                keyModifier: .command,
+                action: #selector(openMacAppStoreReviewURL),
+                target: self
+            ),
+            MenuItem(
+                title: "Equinox on Product Hunt",
+                keyEquivalent: "",
+                keyModifier: .command,
+                action: #selector(openProductHuntURL),
+                target: self
+            )
         ]
         return menu
+    }
+    
+    private enum helpURLs: String {
+        case githubProjectURL = "https://github.com/rlxone/Equinox"
+        case githubFAQURL = "https://github.com/rlxone/Equinox#faq"
+        case githubIssueURL = "https://github.com/rlxone/Equinox/issues"
+        case equinoxWebsiteURL = "https://equinoxmac.com"
+        case macAppStoreReviewURL = "https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?action=write-review"
+        case productHuntURL = "https://www.producthunt.com/products/equinox"
     }
     
     @objc
     private func new(_ sender: Any?) {
         applicationDelegate?.applicationMenuNew(sender)
+    }
+    
+    @objc func unwrapOpenURL(_ url: URL?) {
+        guard let url = url else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+    
+    @objc func openGitHubProjectURL() {
+        unwrapOpenURL(URL(string: helpURLs.githubProjectURL.rawValue))
+    }
+    @objc func openGitHubFAQURL() {
+        unwrapOpenURL(URL(string: helpURLs.githubFAQURL.rawValue))
+    }
+    @objc func openGitHubIssueURL() {
+        unwrapOpenURL(URL(string: helpURLs.githubIssueURL.rawValue))
+    }
+    @objc func openEquinoxWebsiteURL() {
+        unwrapOpenURL(URL(string: helpURLs.equinoxWebsiteURL.rawValue))
+    }
+    @objc func openMacAppStoreReviewURL() {
+        unwrapOpenURL(URL(string: helpURLs.macAppStoreReviewURL.rawValue))
+    }
+    @objc func openProductHuntURL() {
+        unwrapOpenURL(URL(string: helpURLs.productHuntURL.rawValue))
     }
 }

--- a/Equinox/Equinox/Menu/HelpMenuLinks.swift
+++ b/Equinox/Equinox/Menu/HelpMenuLinks.swift
@@ -27,6 +27,7 @@
 // THE SOFTWARE.
 
 import Foundation
+import EquinoxAssets
 
 internal enum helpMenuLinks: CaseIterable {
     case githubProject
@@ -38,17 +39,17 @@ internal enum helpMenuLinks: CaseIterable {
     var linkInfo: (title: String, url: URL?) {
         switch self {
         case .githubProject:
-            return ("GitHub project", URL(string: "https://github.com/rlxone/Equinox"))
+            return (Localization.Menu.Help.githubProject, URL(string: "https://github.com/rlxone/Equinox"))
         case .githubFAQ:
-            return ("Frequently Asked Questions", URL(string: "https://github.com/rlxone/Equinox#faq"))
+            return (Localization.Menu.Help.githubFAQ, URL(string: "https://github.com/rlxone/Equinox#faq"))
         case .githubIssue:
-            return ("Report an issue", URL(string: "https://github.com/rlxone/Equinox/issues"))
+            return (Localization.Menu.Help.githubIssue, URL(string: "https://github.com/rlxone/Equinox/issues"))
         case .equinoxWebsite:
-            return ("Equinox website", URL(string: "https://equinoxmac.com"))
+            return (Localization.Menu.Help.equinoxWebsite, URL(string: "https://equinoxmac.com"))
         case .macAppStoreReview:
-            return ("Rate Equinox on the Mac App Store", URL(string: "https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?action=write-review"))
+            return (Localization.Menu.Help.macAppStoreReview, URL(string: "https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?action=write-review"))
         case .productHunt:
-            return ("Equinox on Product Hunt", URL(string: "https://www.producthunt.com/products/equinox"))
+            return (Localization.Menu.Help.productHunt, URL(string: "https://www.producthunt.com/products/equinox"))
         }
     }
 }

--- a/Equinox/Equinox/Menu/HelpMenuLinks.swift
+++ b/Equinox/Equinox/Menu/HelpMenuLinks.swift
@@ -26,30 +26,49 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import EquinoxAssets
+import Foundation
 
-internal enum helpMenuLinks: CaseIterable {
+internal enum HelpMenuLinks: CaseIterable {
     case githubProject
     case githubFAQ
     case githubIssue
     case equinoxWebsite
     case macAppStoreReview
     case productHunt
+    
     var linkInfo: (title: String, url: URL?) {
         switch self {
         case .githubProject:
-            return (Localization.Menu.Help.githubProject, URL(string: "https://github.com/rlxone/Equinox"))
+            return (
+                Localization.Menu.Help.githubProject,
+                URL(string: "https://github.com/rlxone/Equinox")
+            )
         case .githubFAQ:
-            return (Localization.Menu.Help.githubFAQ, URL(string: "https://github.com/rlxone/Equinox#faq"))
+            return (
+                Localization.Menu.Help.githubFAQ,
+                URL(string: "https://github.com/rlxone/Equinox#faq")
+            )
         case .githubIssue:
-            return (Localization.Menu.Help.githubIssue, URL(string: "https://github.com/rlxone/Equinox/issues"))
+            return (
+                Localization.Menu.Help.githubIssue,
+                URL(string: "https://github.com/rlxone/Equinox/issues")
+            )
         case .equinoxWebsite:
-            return (Localization.Menu.Help.equinoxWebsite, URL(string: "https://equinoxmac.com"))
+            return (
+                Localization.Menu.Help.equinoxWebsite,
+                URL(string: "https://equinoxmac.com")
+            )
         case .macAppStoreReview:
-            return (Localization.Menu.Help.macAppStoreReview, URL(string: "https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?action=write-review"))
+            return (
+                Localization.Menu.Help.macAppStoreReview,
+                URL(string: "https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?action=write-review")
+            )
         case .productHunt:
-            return (Localization.Menu.Help.productHunt, URL(string: "https://www.producthunt.com/products/equinox"))
+            return (
+                Localization.Menu.Help.productHunt,
+                URL(string: "https://www.producthunt.com/products/equinox")
+            )
         }
     }
 }

--- a/Equinox/Equinox/Menu/HelpMenuLinks.swift
+++ b/Equinox/Equinox/Menu/HelpMenuLinks.swift
@@ -29,7 +29,7 @@
 import EquinoxAssets
 import Foundation
 
-internal enum HelpMenuLinks: CaseIterable {
+enum HelpMenuLinks: CaseIterable {
     case githubProject
     case githubFAQ
     case githubIssue

--- a/Equinox/Equinox/Menu/HelpMenuLinks.swift
+++ b/Equinox/Equinox/Menu/HelpMenuLinks.swift
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 William Mead
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// Notwithstanding the foregoing, you may not use, copy, modify, merge, publish,
+// distribute, sublicense, create a derivative work, and/or sell copies of the
+// Software in any work that is designed, intended, or marketed for pedagogical or
+// instructional purposes related to programming, coding, application development,
+// or information technology.  Permission for such use, copying, modification,
+// merger, publication, distribution, sublicensing, creation of derivative works,
+// or sale is expressly withheld.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+internal enum helpMenuLinks: CaseIterable {
+    case githubProject
+    case githubFAQ
+    case githubIssue
+    case equinoxWebsite
+    case macAppStoreReview
+    case productHunt
+    var linkInfo: (title: String, url: URL?) {
+        switch self {
+        case .githubProject:
+            return ("GitHub project", URL(string: "https://github.com/rlxone/Equinox"))
+        case .githubFAQ:
+            return ("Frequently Asked Questions", URL(string: "https://github.com/rlxone/Equinox#faq"))
+        case .githubIssue:
+            return ("Report an issue", URL(string: "https://github.com/rlxone/Equinox/issues"))
+        case .equinoxWebsite:
+            return ("Equinox website", URL(string: "https://equinoxmac.com"))
+        case .macAppStoreReview:
+            return ("Rate Equinox on the Mac App Store", URL(string: "https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?action=write-review"))
+        case .productHunt:
+            return ("Equinox on Product Hunt", URL(string: "https://www.producthunt.com/products/equinox"))
+        }
+    }
+}

--- a/Equinox/Equinox/Menu/MenuItem.swift
+++ b/Equinox/Equinox/Menu/MenuItem.swift
@@ -38,7 +38,7 @@ final class MenuItem: NSMenuItem {
         keyEquivalent charCode: String,
         keyModifier: NSEvent.ModifierFlags,
         action selector: Selector?,
-        target: AnyObject = MenuItem.self as AnyObject,
+        target: AnyObject = self as AnyObject,
         isEnabled: Bool = true
     ) {
         super.init(title: string, action: selector, keyEquivalent: charCode)

--- a/Equinox/Equinox/Menu/MenuItem.swift
+++ b/Equinox/Equinox/Menu/MenuItem.swift
@@ -38,7 +38,7 @@ final class MenuItem: NSMenuItem {
         keyEquivalent charCode: String,
         keyModifier: NSEvent.ModifierFlags,
         action selector: Selector?,
-        target: AnyObject = self as AnyObject,
+        target: AnyObject = MenuItem.self as AnyObject,
         isEnabled: Bool = true
     ) {
         super.init(title: string, action: selector, keyEquivalent: charCode)

--- a/EquinoxAssets/EquinoxAssets/Localization.swift
+++ b/EquinoxAssets/EquinoxAssets/Localization.swift
@@ -77,6 +77,12 @@ public enum Localization {
         
         public enum Help {
             public static let help = Localization.localizedString(key: "menu.help")
+            public static let githubProject = Localization.localizedString(key: "menu.help.githubProject")
+            public static let githubFAQ = Localization.localizedString(key: "menu.help.githubFAQ")
+            public static let githubIssue = Localization.localizedString(key: "menu.help.githubIssue")
+            public static let equinoxWebsite = Localization.localizedString(key: "menu.help.equinoxWebsite")
+            public static let macAppStoreReview = Localization.localizedString(key: "menu.help.macAppStoreReview")
+            public static let productHunt = Localization.localizedString(key: "menu.help.productHunt")
         }
     }
     

--- a/EquinoxAssets/EquinoxAssets/Localization/Localizable.strings
+++ b/EquinoxAssets/EquinoxAssets/Localization/Localizable.strings
@@ -23,6 +23,12 @@
 "menu.window.show.all" = "Show All";
 
 "menu.help" = "Help";
+"menu.help.githubProject" = "GitHub project";
+"menu.help.githubFAQ" = "Frequently Asked Questions";
+"menu.help.githubIssue" = "Report an issue";
+"menu.help.equinoxWebsite" = "Equinox website";
+"menu.help.macAppStoreReview" = "Rate Equinox on the Mac App Store";
+"menu.help.productHunt" = "Equinox on Product Hunt";
 
 "welcome.title" = "Welcome to Equinox";
 "welcome.welcome" = "Welcome to %@";


### PR DESCRIPTION
Hey @rlxone 
Going through Equinox, the help menu felt empty so I looked at what other apps are doing. Help menus seem to mainly contain links to the web or Apple macOS help books ([which seem outdated](https://marioaguzman.wordpress.com/2020/09/12/auth/)). So I rounded up a first batch of interesting links and added them to the `helpMenu`

<img width="978" alt="Capture d’écran 2022-08-15 à 22 20 54" src="https://user-images.githubusercontent.com/31100265/184713605-100ffcb3-1976-4a18-a9ca-38f5d7d0a772.png">

What do you think ? Would you add/remove anything ?

If we go ahead with this I'll update the FR localization in this branch once we've finalized the help menu.

This is also great in helping me to get a first understanding of how AppKit works.

Regards