### PR TITLE
chore(readme): make icon link to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 <div><h1></h1></div>
 
 <div align="center">
-  <img src="repo/logo.png" width="200" height="200"/>
+  <a href="https://equinoxmac.com/">
+    <img src="repo/logo.png" width="200" height="200"/>
+  </a>
   <h1>Equinox</h1>
   <p>Create dynamic wallpapers for macOS</p>
   <br>


### PR DESCRIPTION
My first instinct coming to this repo was to click on the icon (which is very pretty btw), but it unfortunately only led to the file in the repo.

It should probably lead to the website when clicked.

EDIT: absolutely stunning looking app, website and logo, huge props. App works perfect as well. Fantastic job.