### PR TITLE
Fix dynamic wallpaper import and save flow

### DIFF
--- a/Equinox/Equinox/Stories/Common/ImageProvider.swift
+++ b/Equinox/Equinox/Stories/Common/ImageProvider.swift
@@ -28,6 +28,14 @@
 
 import AppKit
 import EquinoxCore
+import ImageIO
+
+struct ImportedWallpaperItem {
+    let url: URL
+    let azimuth: Double?
+    let altitude: Double?
+    let time: Date?
+}
 
 // MARK: - Protocols
 
@@ -39,6 +47,7 @@ protocol ImageProvider {
     )
     func validateImages(_ urls: [URL]) -> [URL]
     func getImageMetadata(for url: URL) -> ExifMetadata?
+    func getWallpaperItems(for url: URL) -> [ImportedWallpaperItem]?
 }
 
 // MARK: - Enums, Structs
@@ -129,5 +138,143 @@ final class ImageProviderImpl: ImageProvider {
         } catch {
             return nil
         }
+    }
+
+    func getWallpaperItems(for url: URL) -> [ImportedWallpaperItem]? {
+        guard
+            let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+            let imageMetadata = readWallpaperMetadata(source: source)
+        else {
+            return nil
+        }
+
+        if let solarMetadata = imageMetadata.solarMetadata {
+            let sortedMetadata = solarMetadata.sorted { $0.index < $1.index }
+            return sortedMetadata.compactMap {
+                guard let exportedURL = exportImage(source: source, index: $0.index, originalURL: url) else {
+                    return nil
+                }
+                return ImportedWallpaperItem(url: exportedURL, azimuth: $0.azimuth, altitude: $0.altitude, time: nil)
+            }
+        }
+
+        if let timeMetadata = imageMetadata.timeMetadata {
+            let sortedMetadata = timeMetadata.sorted { $0.index < $1.index }
+            return sortedMetadata.compactMap {
+                guard let exportedURL = exportImage(source: source, index: $0.index, originalURL: url) else {
+                    return nil
+                }
+                return ImportedWallpaperItem(
+                    url: exportedURL,
+                    azimuth: nil,
+                    altitude: nil,
+                    time: makeDate(from: $0.time)
+                )
+            }
+        }
+
+        return nil
+    }
+
+    private func readWallpaperMetadata(source: CGImageSource) -> ImportedImageMetadata? {
+        guard
+            let metadata = CGImageSourceCopyMetadataAtIndex(source, 0, nil),
+            let tags = CGImageMetadataCopyTags(metadata) as? [CGImageMetadataTag]
+        else {
+            return nil
+        }
+
+        for type in ImportedImageMetadataType.allCases {
+            guard
+                let tag = tags.first(where: { CGImageMetadataTagCopyName($0) as String? == type.rawValue }),
+                let tagValue = CGImageMetadataTagCopyValue(tag) as? String,
+                let decodedValue = Data(base64Encoded: tagValue)
+            else {
+                continue
+            }
+
+            let decoder = PropertyListDecoder()
+            return try? decoder.decode(ImportedImageMetadata.self, from: decodedValue)
+        }
+
+        return nil
+    }
+
+    private func exportImage(source: CGImageSource, index: Int, originalURL: URL) -> URL? {
+        guard
+            index < CGImageSourceGetCount(source),
+            let image = CGImageSourceCreateImageAtIndex(source, index, nil),
+            let sourceType = CGImageSourceGetType(source)
+        else {
+            return nil
+        }
+
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("equinox-import-\(UUID().uuidString)", isDirectory: true)
+
+        do {
+            try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        } catch {
+            return nil
+        }
+
+        let fileExtension = originalURL.pathExtension.isEmpty ? "heic" : originalURL.pathExtension
+        let filename = String(format: "%03d.%@", index, fileExtension)
+        let outputURL = temporaryDirectory.appendingPathComponent(filename)
+
+        guard let destination = CGImageDestinationCreateWithURL(outputURL as CFURL, sourceType, 1, nil) else {
+            return nil
+        }
+
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            return nil
+        }
+
+        return outputURL
+    }
+
+    private func makeDate(from time: Double) -> Date {
+        let calendar = getCurrentCalendar
+        let startOfDay = calendar.startOfDay(for: Date())
+        let seconds = Int(round(time * Double(24 * 60 * 60)))
+        return calendar.date(byAdding: .second, value: seconds, to: startOfDay) ?? startOfDay
+    }
+}
+
+private enum ImportedImageMetadataType: String, CaseIterable {
+    case solar = "solar"
+    case time = "h24"
+}
+
+private struct ImportedImageMetadata: Decodable {
+    let solarMetadata: [ImportedSolarMetadata]?
+    let timeMetadata: [ImportedTimeMetadata]?
+
+    enum CodingKeys: String, CodingKey {
+        case solarMetadata = "si"
+        case timeMetadata = "ti"
+    }
+}
+
+private struct ImportedSolarMetadata: Decodable {
+    let index: Int
+    let altitude: Double
+    let azimuth: Double
+
+    enum CodingKeys: String, CodingKey {
+        case index = "i"
+        case altitude = "a"
+        case azimuth = "z"
+    }
+}
+
+private struct ImportedTimeMetadata: Decodable {
+    let index: Int
+    let time: Double
+
+    enum CodingKeys: String, CodingKey {
+        case index = "i"
+        case time = "t"
     }
 }

--- a/Equinox/Equinox/Stories/Solar/SolarDateAndTimeController.swift
+++ b/Equinox/Equinox/Stories/Solar/SolarDateAndTimeController.swift
@@ -77,7 +77,9 @@ final class SolarDateAndTimeController {
     }
     
     func setTimezone(identifier: String) {
+        let previousTimezone = currentTimezone.underlyingTimezone
         currentTimezone = cachedTimezones[identifier] ?? currentTimezone
+        currentDate = merge(date: currentDate, seconds: currentTime, sourceTimezone: previousTimezone) ?? currentDate
     }
     
     var selectedTimezone: ExtendedTimezone {
@@ -87,6 +89,10 @@ final class SolarDateAndTimeController {
     var selectedDate: Date {
         return currentDate
     }
+
+    var selectedTimeZone: TimeZone {
+        currentTimezone.underlyingTimezone
+    }
     
     var continentTimezones: [String: [ExtendedTimezone]] {
         return convertToContinentTimezones(timezones: cachedTimezones)
@@ -95,7 +101,7 @@ final class SolarDateAndTimeController {
     var abbreviation: String {
         return getGMTHours(
             from: currentTimezone.underlyingTimezone,
-            date: endOfDay
+            date: currentDate
         )
     }
     
@@ -110,16 +116,16 @@ final class SolarDateAndTimeController {
     func abbreviation(identifier: String) -> String {
         return getGMTHours(
             from: timezone(identifier: identifier).underlyingTimezone,
-            date: endOfDay
+            date: currentDate
         )
     }
     
     var isDaylightSavingTime: Bool {
-        return currentTimezone.underlyingTimezone.isDaylightSavingTime(for: endOfDay)
+        return currentTimezone.underlyingTimezone.isDaylightSavingTime(for: currentDate)
     }
     
     var secondsFromGMT: Int {
-        currentTimezone.underlyingTimezone.secondsFromGMT(for: endOfDay)
+        currentTimezone.underlyingTimezone.secondsFromGMT(for: currentDate)
     }
     
     func convertToHours(seconds: Int) -> Int {
@@ -141,7 +147,7 @@ final class SolarDateAndTimeController {
     // MARK: - Private
     
     private var endOfDay: Date {
-        let calendar = getCurrentCalendar
+        let calendar = makeCalendar(timezone: currentTimezone.underlyingTimezone)
         let endOfDayTimeInterval = TimeInterval(Constants.oneDaySeconds - 1)
         let endOfDay = calendar.startOfDay(for: currentDate).addingTimeInterval(endOfDayTimeInterval)
         return endOfDay
@@ -173,24 +179,16 @@ final class SolarDateAndTimeController {
         return timezonesDictionary
     }
     
-    private func merge(date: Date, seconds: Int) -> Date? {
-        let calendar = getCurrentCalendar
-        
-        let startTime = calendar.startOfDay(for: date)
-        let timeDate = calendar.date(byAdding: .second, value: seconds, to: startTime) ?? date
-        
-        let dateComponents = calendar.dateComponents([.year, .month, .day], from: date)
-        let timeComponents = calendar.dateComponents([.hour, .minute, .second], from: timeDate)
+    private func merge(date: Date, seconds: Int, sourceTimezone: TimeZone? = nil) -> Date? {
+        let sourceCalendar = makeCalendar(timezone: sourceTimezone ?? currentTimezone.underlyingTimezone)
+        let targetCalendar = makeCalendar(timezone: currentTimezone.underlyingTimezone)
+        let dateComponents = sourceCalendar.dateComponents([.year, .month, .day], from: date)
 
-        var mergedComponents = DateComponents()
-        mergedComponents.year = dateComponents.year
-        mergedComponents.month = dateComponents.month
-        mergedComponents.day = dateComponents.day
-        mergedComponents.hour = timeComponents.hour
-        mergedComponents.minute = timeComponents.minute
-        mergedComponents.second = timeComponents.second
-        
-        return calendar.date(from: mergedComponents)
+        guard let startOfDay = targetCalendar.date(from: dateComponents) else {
+            return nil
+        }
+
+        return targetCalendar.date(byAdding: .second, value: seconds, to: startOfDay)
     }
     
     private func getGMTHours(from timezone: TimeZone, date: Date) -> String {
@@ -211,5 +209,11 @@ final class SolarDateAndTimeController {
         }
         
         return string
+    }
+
+    private func makeCalendar(timezone: TimeZone) -> Calendar {
+        var calendar = getCurrentCalendar
+        calendar.timeZone = timezone
+        return calendar
     }
 }

--- a/Equinox/Equinox/Stories/Solar/SolarMainViewController.swift
+++ b/Equinox/Equinox/Stories/Solar/SolarMainViewController.swift
@@ -335,7 +335,8 @@ final class SolarMainViewController: ViewController {
     }
     
     private func reloadChartData() {
-        let calendar = getCurrentCalendar
+        var calendar = getCurrentCalendar
+        calendar.timeZone = dateAndTimeController.selectedTimeZone
         
         let startTime = calendar.startOfDay(for: dateAndTimeController.selectedDate)
         var chartData: [InteractiveLineChart.ChartData] = []

--- a/Equinox/Equinox/Stories/Wallpaper/WallpaperCreateViewController.swift
+++ b/Equinox/Equinox/Stories/Wallpaper/WallpaperCreateViewController.swift
@@ -46,7 +46,8 @@ protocol WallpaperCreateViewControllerDelegate: AnyObject {
 extension WallpaperCreateViewController {
     private enum Constants {
         static let thumbnailSize = NSSize(width: 768, height: 425.25)
-        static let imageFilename = "wallpaper.heic"
+        static let imageFilename = "wallpaper"
+        static let imageExtension = "heic"
         static let defaultDelay: TimeInterval = 0.3
     }
 }
@@ -269,8 +270,8 @@ final class WallpaperCreateViewController: ViewController {
             }
 
             let finalURL = panelURL.pathExtension.isEmpty
-                ? panelURL.appendingPathExtension("heic")
-                : panelURL
+                ? panelURL.appendingPathExtension(Constants.imageExtension)
+                : panelURL.deletingPathExtension().appendingPathExtension(Constants.imageExtension)
 
             do {
                 try createdImage.write(to: finalURL, options: .atomic)

--- a/Equinox/Equinox/Stories/Wallpaper/WallpaperGalleryDataController.swift
+++ b/Equinox/Equinox/Stories/Wallpaper/WallpaperGalleryDataController.swift
@@ -31,12 +31,6 @@ import EquinoxAssets
 import EquinoxCore
 import EquinoxUI
 
-extension WallpaperGalleryDataController {
-    private enum Constants {
-        static let oneDaySeconds = 24 * 60 * 60
-    }
-}
-
 final class WallpaperGalleryDataController {
     private let type: WallpaperType
     private let fileService: FileService
@@ -104,15 +98,36 @@ final class WallpaperGalleryDataController {
         let oneImageInterval = oneDaySeconds / urls.count
         
         for (index, url) in urls.enumerated() {
-            let newIndex = insertIndexPath.item + index
+            let importedItems = importedWallpaperItems(for: url)
+
+            if !importedItems.isEmpty {
+                for importedItem in importedItems {
+                    let newIndex = insertIndexPath.item + newData.count
+                    let indexPath = IndexPath(item: newIndex, section: insertIndexPath.section)
+                    let count = data.items.count + newData.count
+                    let model = GalleryModel(
+                        number: newIndex + 1,
+                        url: importedItem.url,
+                        appearance: .all,
+                        primary: isPrimaryIndex(count),
+                        azimuth: importedItem.azimuth,
+                        altitude: importedItem.altitude,
+                        time: importedItem.time
+                    )
+                    newData.append((indexPath, model))
+                }
+                continue
+            }
+
+            let newIndex = insertIndexPath.item + newData.count
             let indexPath = IndexPath(item: newIndex, section: insertIndexPath.section)
-            let count = data.items.count + index
-            
+            let count = data.items.count + newData.count
+
             let isPrimary = isPrimaryIndex(count)
             let imageData = calculateImageData(url)
             let addingInterval = data.items.isEmpty ? oneImageInterval * index : 0
             let time = calendar.date(byAdding: .second, value: addingInterval, to: startTime)
-            
+
             let model = GalleryModel(
                 number: newIndex + 1,
                 url: url,
@@ -122,7 +137,7 @@ final class WallpaperGalleryDataController {
                 altitude: imageData?.altitude,
                 time: time
             )
-            
+
             newData.append((indexPath, model))
         }
         
@@ -171,8 +186,7 @@ final class WallpaperGalleryDataController {
             return nil
         }
         let timezone = metadata.timezone ?? .current
-        let endOfDate = endOfDay(date: date)
-        let timezoneHours = timezone.secondsFromGMT(for: endOfDate) / 60 / 60
+        let timezoneHours = timezone.secondsFromGMT(for: date) / 60 / 60
         guard
             let solarAzimuth = try? solarService.azimuth(
                 latitude: latitude,
@@ -196,6 +210,19 @@ final class WallpaperGalleryDataController {
         return (azimuth, altitude)
     }
 
+    private func importedWallpaperItems(for url: URL) -> [ImportedWallpaperItem] {
+        switch type {
+        case .solar:
+            return imageProvider.getWallpaperItems(for: url)?.filter { $0.azimuth != nil && $0.altitude != nil } ?? []
+
+        case .time:
+            return imageProvider.getWallpaperItems(for: url)?.filter { $0.time != nil } ?? []
+
+        case .appearance:
+            return []
+        }
+    }
+
     private func calculateFilesize(_ url: URL) -> UInt64? {
         do {
             let filesize = try fileService.getFilesize(url)
@@ -216,12 +243,5 @@ final class WallpaperGalleryDataController {
     private func roundDouble(_ value: Double, places: Int) -> Double {
         let divisor = pow(10.0, Double(places))
         return round(value * divisor) / divisor
-    }
-    
-    private func endOfDay(date: Date) -> Date {
-        let calendar = getCurrentCalendar
-        let endOfDayTimeInterval = TimeInterval(Constants.oneDaySeconds - 1)
-        let endOfDay = calendar.startOfDay(for: date).addingTimeInterval(endOfDayTimeInterval)
-        return endOfDay
     }
 }

--- a/EquinoxCore/EquinoxCore/Cores/MetadataCore.swift
+++ b/EquinoxCore/EquinoxCore/Cores/MetadataCore.swift
@@ -86,8 +86,8 @@ public final class MetadataCoreImpl: MetadataCore {
         }
         
         if let exifDictionary = exifDictionary {
-            date = getDate(from: exifDictionary)
             timezone = getTimezone(from: exifDictionary)
+            date = getDate(from: exifDictionary, timezone: timezone)
         }
         
         return ExifMetadata(
@@ -208,11 +208,11 @@ public final class MetadataCoreImpl: MetadataCore {
         return (latitude, longitude)
     }
     
-    private func getDate(from exifData: [String: Any]) -> Date? {
+    private func getDate(from exifData: [String: Any], timezone: TimeZone?) -> Date? {
         let dateString = exifData[kCGImagePropertyExifDateTimeOriginal as String] as? String
         
         let dateFormatter = DateFormatter()
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        dateFormatter.timeZone = timezone ?? TimeZone(secondsFromGMT: 0)
         dateFormatter.dateFormat = "yyyy:MM:dd HH:mm:ss"
         
         var date: Date?

--- a/EquinoxCore/EquinoxCore/Cores/SolarCore.swift
+++ b/EquinoxCore/EquinoxCore/Cores/SolarCore.swift
@@ -45,7 +45,7 @@ public final class SolarCoreImpl: SolarCore {
     // MARK: - Public
 
     public func altitude(latitude: Double, longitude: Double, date: Date, timezone: Int, dlstime: Int) -> Double {
-        let calendar = getCurrentCalendar
+        let calendar = makeCalendar(timezone: timezone, dlstime: dlstime)
         
         let year = calendar.component(.year, from: date)
         let month = calendar.component(.month, from: date)
@@ -69,7 +69,7 @@ public final class SolarCoreImpl: SolarCore {
     }
     
     public func azimuth(latitude: Double, longitude: Double, date: Date, timezone: Int, dlstime: Int) -> Double {
-        let calendar = getCurrentCalendar
+        let calendar = makeCalendar(timezone: timezone, dlstime: dlstime)
         
         let year = calendar.component(.year, from: date)
         let month = calendar.component(.month, from: date)
@@ -90,5 +90,14 @@ public final class SolarCoreImpl: SolarCore {
             timezone: timezone,
             dlstime: dlstime
         )
+    }
+
+    private func makeCalendar(timezone: Int, dlstime: Int) -> Calendar {
+        var calendar = getCurrentCalendar
+        let secondsFromGMT = (timezone + dlstime) * 60 * 60
+        if let effectiveTimeZone = TimeZone(secondsFromGMT: secondsFromGMT) {
+            calendar.timeZone = effectiveTimeZone
+        }
+        return calendar
     }
 }

--- a/EquinoxCore/EquinoxCoreTests/MetadataCoreTests.swift
+++ b/EquinoxCore/EquinoxCoreTests/MetadataCoreTests.swift
@@ -26,6 +26,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import AppKit
+import CoreServices
 import EquinoxCore
 import XCTest
 
@@ -208,6 +210,28 @@ class MetadataCoreTests: XCTestCase {
         XCTAssertNotNil(metadata?.latitude)
         XCTAssertNotNil(metadata?.createDate)
     }
+
+    func testImageMetadataPreservesExifTimezone() throws {
+        guard #available(macOS 10.15, *) else {
+            throw XCTSkip("EXIF offset metadata requires macOS 10.15 or newer")
+        }
+
+        // Given
+        let timezone = try XCTUnwrap(TimeZone(secondsFromGMT: -(5 * 60 * 60)))
+        let url = try makeImage(
+            exifDictionary: [
+                kCGImagePropertyExifDateTimeOriginal as String: "2021:09:28 12:00:00",
+                kCGImagePropertyExifOffsetTimeOriginal as String: "-05:00"
+            ]
+        )
+
+        // When
+        let metadata = try metadataCore.getImageMetadata(for: url)
+
+        // Then
+        XCTAssertEqual(metadata.timezone?.secondsFromGMT(), timezone.secondsFromGMT())
+        XCTAssertEqual(metadata.createDate, makeDate(day: 28, month: 9, year: 2_021, hour: 12, minute: 0, second: 0, timezone: timezone))
+    }
     
     private func getTestMetadata(key: String) -> String? {
         // swiftlint:disable:next force_unwrapping
@@ -226,7 +250,10 @@ class MetadataCoreTests: XCTestCase {
     
     private func getDate(day: Int, month: Int, year: Int, hour: Int, minute: Int, second: Int) throws -> Date {
         let timezone = TimeZone(abbreviation: "GMT") ?? .current
-        
+        return makeDate(day: day, month: month, year: year, hour: hour, minute: minute, second: second, timezone: timezone)
+    }
+
+    private func makeDate(day: Int, month: Int, year: Int, hour: Int, minute: Int, second: Int, timezone: TimeZone) -> Date {
         var dateComponents = DateComponents()
         dateComponents.day = day
         dateComponents.month = month
@@ -242,5 +269,33 @@ class MetadataCoreTests: XCTestCase {
         // swiftlint:disable:next force_unwrapping
         let date = calendar.date(from: dateComponents)!
         return date
+    }
+
+    private func makeImage(exifDictionary: [String: Any]) throws -> URL {
+        let filename = UUID().uuidString + ".jpg"
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(filename)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let context = try XCTUnwrap(
+            CGContext(
+                data: nil,
+                width: 1,
+                height: 1,
+                bitsPerComponent: 8,
+                bytesPerRow: 4,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )
+        )
+        context.setFillColor(NSColor.white.cgColor)
+        context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+
+        let image = try XCTUnwrap(context.makeImage())
+        let destination = try XCTUnwrap(
+            CGImageDestinationCreateWithURL(url as CFURL, kUTTypeJPEG, 1, nil)
+        )
+        let properties = [kCGImagePropertyExifDictionary as String: exifDictionary] as CFDictionary
+        CGImageDestinationAddImage(destination, image, properties)
+        XCTAssertTrue(CGImageDestinationFinalize(destination))
+        return url
     }
 }

--- a/EquinoxCore/EquinoxCoreTests/SolarCoreTests.swift
+++ b/EquinoxCore/EquinoxCoreTests/SolarCoreTests.swift
@@ -63,9 +63,42 @@ class SolarCoreTests: XCTestCase {
         // Then
         XCTAssertEqual(altitude, result)
     }
+
+    func testLocalNoonUsesLocalTimeComponents() {
+        // Given
+        let longitude = -87.623177
+        let latitude = 41.881832
+        let date = getDate(
+            day: 28,
+            month: 9,
+            year: 2_021,
+            hour: 12,
+            minute: 0,
+            second: 0,
+            timezoneIdentifier: "America/Chicago"
+        )
+        let azimuthResult = 165.47055862775676
+        let altitudeResult = 44.867448682164884
+
+        // When
+        let azimuth = solarCore.azimuth(latitude: latitude, longitude: longitude, date: date, timezone: -5, dlstime: 0)
+        let altitude = solarCore.altitude(latitude: latitude, longitude: longitude, date: date, timezone: -5, dlstime: 0)
+
+        // Then
+        XCTAssertEqual(azimuth, azimuthResult)
+        XCTAssertEqual(altitude, altitudeResult)
+    }
     
-    private func getDate(day: Int, month: Int, year: Int, hour: Int, minute: Int, second: Int) -> Date {
-        let timeZone = TimeZone(abbreviation: "GMT") ?? .current
+    private func getDate(
+        day: Int,
+        month: Int,
+        year: Int,
+        hour: Int,
+        minute: Int,
+        second: Int,
+        timezoneIdentifier: String = "GMT"
+    ) -> Date {
+        let timeZone = TimeZone(identifier: timezoneIdentifier) ?? TimeZone(abbreviation: "GMT") ?? .current
         
         var dateComponents = DateComponents()
         dateComponents.timeZone = timeZone


### PR DESCRIPTION
New functionality added:
- Import all frames and metadata for solar / time of day based wallpapers when importing via heic
- Fixed unable to save with different name from "wallpaper" bug 
- Fixed a timezone issue I was having with the calculator